### PR TITLE
Remove peer dep on loopback-datasource-juggler

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "soap": "~0.4.7",
     "debug": "~1.0.2"
   },
-  "peerDependencies": {
-    "loopback-datasource-juggler": "1.x.x"
-  },
   "devDependencies": {
     "loopback-datasource-juggler": "1.x.x",
     "loopback": "1.x.x",


### PR DESCRIPTION
The connector does not require anything from the juggler at all.

See strongloop/loopback#275 for more details about this change.

/to @raymondfeng Please review.
