### PR TITLE
Drop support for Node.js 14 and lower

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,11 +15,11 @@ jobs:
     name: Test
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [16, 18]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            node-version: 14
+            node-version: 16
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,10 +64,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify commit linting


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Node.js 14 and lower versions have reached end-of-life: https://nodejs.dev/en/about/releases/.


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
