### PR TITLE
chore: drop support for Node.js 16 and lower

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,11 +15,11 @@ jobs:
     name: Test
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            node-version: 16
+            node-version: 18
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,10 +64,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify commit linting

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "loopback-connector-soap",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.1",
@@ -23,7 +23,7 @@
         "should": "^13.2.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.4",
   "description": "LoopBack SOAP Web Services Connector",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js 16 and lower

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
